### PR TITLE
Add cfn-python-lint Test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,47 @@
-language: shell
+language: bash
+
 env:
   global:
     - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
     - SEGFAULT_SIGNALS=all
 
-matrix:
+jobs:
   include:
-    - env:
+    - stage: test
+      name: "Shell Syntax-Check"
+      env:
         - TESTENV=shellcheck
         - TESTCOMMAND="find $TRAVIS_BUILD_DIR -name '*.sh' -type f -print0 | xargs -0 -n1 -t shellcheck"
         - SHELLCHECK_OPTS="-s bash"
-    - env:
+      before_install:
+        - echo $TESTCOMMAND
+        - shellcheck --version
+    - stage: test
+      name: "Template JSON Syntax-Check"
+      env:
         - TESTENV=json-tool
         - TESTCOMMAND="find $TRAVIS_BUILD_DIR -name '*.json' -type f -print0 | xargs -0 -n1 -I {} -t jq --exit-status . {} > /dev/null"
-
-before_install:
-  - echo $TESTCOMMAND
-  - shellcheck --version
-
-install:
-  # Download json parser
-  - curl -sO http://stedolan.github.io/jq/download/linux64/jq
-  - chmod +x $PWD/jq
+      install:
+        # Download json parser
+        - curl -sO http://stedolan.github.io/jq/download/linux64/jq
+        - chmod +x $PWD/jq
+    - stage: test
+      name: "Template CFn Syntax-Check"
+      language: python
+      python: 3.6
+      env:
+        - TESTENV=cfn-lint
+        # E1029: Because it chokes on BASH vars in 'content' blocks
+        # E2015: Because can't identify why it's failing on the test (relevant content is valid)
+        - TESTCOMMAND="find $TRAVIS_BUILD_DIR -name '*.json' -type f -print0 | xargs -0 -n1 -I {} -t cfn-lint -i E1029,E2015 -t {} > /dev/null"
+      install:
+        - pip install cfn-lint
 
 script:
   - bash -c "$TESTCOMMAND"
+
+stages:
+  - test
 
 notifications:
   email:

--- a/Templates/make_gitlab_ELBv1.tmplt.json
+++ b/Templates/make_gitlab_ELBv1.tmplt.json
@@ -77,10 +77,10 @@
       "Type": "String"
     },
     "GitLabListenPort": {
-      "Default": "443",
+      "Default": 443,
       "Description": "TCP Port number on which the GitLab ELB listens for requests.",
-      "MaxValue": "65535",
-      "MinValue": "1",
+      "MaxValue": 65535,
+      "MinValue": 1,
       "Type": "Number"
     },
     "GitLabListenerCert": {
@@ -90,17 +90,17 @@
     },
     "GitLabPassesSsh": {
       "AllowedValues": [
-        "false",
-        "true"
+        false,
+        true
       ],
-      "Default": "true",
+      "Default": true,
       "Description": "Whether to allow SSH passthrough to GitLab master.",
-      "Type": "String"
+      "Type": "Number"
     },
     "GitLabServicePort": {
-      "Default": "80",
+      "Default": 80,
       "Description": "TCP Port number that the GitLab host listens to.",
-      "MaxValue": "65535",
+      "MaxValue": 65535,
       "Type": "Number"
     },
     "HaSubnets": {
@@ -129,7 +129,7 @@
     "GitLabPubElb": {
       "Metadata": {},
       "Properties": {
-        "CrossZone": "true",
+        "CrossZone": true,
         "HealthCheck": {
           "HealthyThreshold": "5",
           "Interval": "30",

--- a/Templates/make_gitlab_GlusterFS-node.tmplt.json
+++ b/Templates/make_gitlab_GlusterFS-node.tmplt.json
@@ -113,7 +113,7 @@
     "AmiId": {
       "AllowedPattern": "^ami-[0-9a-z]{8}$|^ami-[0-9a-z]{17}$",
       "Description": "ID of the AMI to launch",
-      "Type": "String"
+      "Type": "AWS::EC2::Image::Id"
     },
     "CfnEndpointUrl": {
       "AllowedPattern": "^$|^http://.*$|^https://.*$",
@@ -325,7 +325,7 @@
           {
             "DeviceName": "/dev/xvda",
             "Ebs": {
-              "VolumeSize": "20",
+              "VolumeSize": 20,
               "VolumeType": "gp2"
             }
           },
@@ -335,7 +335,7 @@
             {
               "DeviceName": { "Ref": "ShareVolDev" },
               "Ebs": {
-              "DeleteOnTermination": "true",
+              "DeleteOnTermination": true,
               "VolumeSize": { "Ref": "ShareVolSize" },
               "VolumeType": { "Ref": "ShareVolType" }
               }

--- a/Templates/make_gitlab_RDS-pgsql.tmplt.json
+++ b/Templates/make_gitlab_RDS-pgsql.tmplt.json
@@ -66,7 +66,6 @@
             "default": "RDS Network Configuration"
           },
           "Parameters": [
-            "TargetVPC", 
             "DbSubnets",
             "DbSecurityGroup"
           ]
@@ -213,11 +212,6 @@
       "Default": "9.6.10",
       "Description": "The X.Y.Z version of the PostGreSQL database to deploy.",
       "Type": "String"
-    },
-    "TargetVPC": {
-      "AllowedPattern": "^vpc-[0-9a-f]*$",
-      "Description": "ID of the VPC to deploy cluster nodes into.",
-      "Type": "AWS::EC2::VPC::Id"
     }
   },
   "Resources": {
@@ -225,8 +219,8 @@
       "Metadata": {},
       "Properties": {
         "AllocatedStorage": { "Ref": "DbDataSize" },
-        "AllowMajorVersionUpgrade": "true",
-        "AutoMinorVersionUpgrade": "true",
+        "AllowMajorVersionUpgrade": true,
+        "AutoMinorVersionUpgrade": true,
         "BackupRetentionPeriod": "7",
         "DBInstanceClass": { "Ref": "DbInstanceType" },
         "DBInstanceIdentifier": {
@@ -272,7 +266,7 @@
         "MultiAZ": { "Ref": "DbIsMultiAz" },
         "PreferredBackupWindow": "23:30-00:00",
         "PreferredMaintenanceWindow": "sun:00:30-sun:01:00",
-        "PubliclyAccessible": "false",
+        "PubliclyAccessible": false,
         "StorageType": { "Ref": "DbStorageType" },
         "VPCSecurityGroups": { "Ref": "DbSecurityGroup" }
       },

--- a/Templates/make_gitlab_S3-main_bucket.tmplt.json
+++ b/Templates/make_gitlab_S3-main_bucket.tmplt.json
@@ -49,11 +49,6 @@
       "Description": "Number of days to retain objects before aging them out of the bucket",
       "Type": "Number"
     },
-    "Folder": {
-      "AllowedPattern": "^[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]*$|^$",
-      "Description": "S3 bucket-folder to host backups of GitLab config- and app-data",
-      "Type": "String"
-    },
     "ReportingBucket": {
       "AllowedPattern": "^arn:.*$|^$",
       "ConstraintDescription": "String must start with 'arn:' (or be left wholly blank).",
@@ -121,7 +116,7 @@
                   "Format": "CSV",
                   "Prefix": "StorageReporting/Inventory"
                 },
-                "Enabled": "true",
+                "Enabled": true,
                 "Id": "Inventory",
                 "IncludedObjectVersions": "Current",
                 "Prefix": "Backups/",

--- a/Templates/make_gitlab_SGs.tmplt.json
+++ b/Templates/make_gitlab_SGs.tmplt.json
@@ -43,14 +43,13 @@
       }
     },
     "UpdateRdsSg": {
-      "DependsOn": "RdsSg",
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
         "GroupId": { "Ref": "RdsSg" },
         "SourceSecurityGroupId": { "Ref": "RdsSg" },
         "IpProtocol": "tcp",
-        "FromPort": "5432",
-        "ToPort": "5432"
+        "FromPort": 5432,
+        "ToPort": 5432
       }
     },
     "NasSg": {
@@ -62,14 +61,13 @@
       }
     },
     "UpdateNasSg": {
-      "DependsOn": "NasSg",
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
         "GroupId": { "Ref": "NasSg" },
         "SourceSecurityGroupId": { "Ref": "NasSg" },
         "IpProtocol": "tcp",
-        "FromPort": "0",
-        "ToPort": "65535"
+        "FromPort": 0,
+        "ToPort": 65535
       }
     },
     "AppSg": {
@@ -79,20 +77,20 @@
         "SecurityGroupIngress": [
           {
             "IpProtocol": "tcp",
-            "FromPort": "22",
-            "ToPort": "22",
+            "FromPort": 22,
+            "ToPort": 22,
             "CidrIp": "0.0.0.0/0"
           },
           {
             "IpProtocol": "tcp",
-            "FromPort": "80",
-            "ToPort": "80",
+            "FromPort": 80,
+            "ToPort": 80,
             "CidrIp": "0.0.0.0/0"
           },
           {
             "IpProtocol": "tcp",
-            "FromPort": "443",
-            "ToPort": "443",
+            "FromPort": 443,
+            "ToPort": 443,
             "CidrIp": "0.0.0.0/0"
           }
         ],
@@ -101,14 +99,13 @@
       }
     },
     "UpdateAppSg": {
-      "DependsOn": "AppSg",
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
         "GroupId": { "Ref": "AppSg" },
         "SourceSecurityGroupId": { "Ref": "AppSg" },
         "IpProtocol": "tcp",
-        "FromPort": "0",
-        "ToPort": "65535"
+        "FromPort": 0,
+        "ToPort": 65535
       }
     }
   }

--- a/Templates/make_gitlab_parent-GlusterFS.tmplt.json
+++ b/Templates/make_gitlab_parent-GlusterFS.tmplt.json
@@ -86,7 +86,6 @@
             "GitLabRpmName",
             "GitLabPrepScript",
             "GitLabConfScript",
-            "BackupFolder",
             "LdapHost",
             "LdapPort",
             "LdapCrypt",
@@ -128,10 +127,6 @@
       "MaxValue": "16384",
       "MinValue": "5",
       "Type": "Number"
-    },
-    "BackupFolder": {
-      "Description": "Folder in S3 Bucket to host backups of GitLab config-data",
-      "Type": "String"
     },
     "CfnEndpointUrl": {
       "AllowedPattern": "^$|^http://.*$|^https://.*$",
@@ -539,7 +534,7 @@
         },
         "TemplateURL": { "Ref": "GitlabEc2Template"
         },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -724,7 +719,7 @@
         "TemplateURL": {
           "Ref": "GitlabIamTemplate"
         },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -786,7 +781,7 @@
         "TemplateURL": {
           "Ref": "GitlabBucketTemplate"
         },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -800,7 +795,7 @@
         "TemplateURL": {
           "Ref": "SecurityGroupTemplate"
         },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     }

--- a/Templates/make_gitlab_parent-autoscale-EFS.tmplt.json
+++ b/Templates/make_gitlab_parent-autoscale-EFS.tmplt.json
@@ -623,7 +623,7 @@
           "WatchmakerS3Source": { "Ref": "WatchmakerS3Source" }
         },
         "TemplateURL": { "Ref": "GitlabAsgTemplate" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -652,7 +652,7 @@
           }
         },
         "TemplateURL": { "Ref": "GitlabElbTemplate" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -669,7 +669,7 @@
           "ServiceTld": { "Ref": "ServiceTld" }
         },
         "TemplateURL": { "Ref": "GitlabEfsTemplate" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -685,7 +685,7 @@
           "ServiceTld": { "Ref": "ServiceTld" }
         },
         "TemplateURL": { "Ref": "GitlabIamTemplate" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -719,7 +719,7 @@
           "GitlabBucket": { "Ref": "GitlabBucket" }
         },
         "TemplateURL": { "Ref": "GitlabBucketTemplate" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -729,7 +729,7 @@
           "TargetVPC": { "Ref": "TargetVPC" }
         },
         "TemplateURL": { "Ref": "SecurityGroupTemplate" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     }

--- a/Templates/make_gitlab_parent-infra-EFS.tmplt.json
+++ b/Templates/make_gitlab_parent-infra-EFS.tmplt.json
@@ -33,20 +33,6 @@
         },
         {
           "Label": {
-            "default": "Git Build-Parameters"
-          },
-          "Parameters": [
-            "ProxyName",
-            "GitLabRpmName",
-            "GitLabPrepScript",
-            "GitLabConfScript",
-            "GitlabBucket",
-            "GitRepoShareFsPath",
-            "GitRepoShareType"
-          ]
-        },
-        {
-          "Label": {
             "default": "Proxy (ELB)"
           },
           "Parameters": [
@@ -61,9 +47,9 @@
             "default": "Miscellaneous"
           },
           "Parameters": [
-            "ServiceTld",
             "TargetVPC",
             "HaSvcSubnets",
+            "GitlabBucket",
             "RolePrefix"
           ]
         }
@@ -189,15 +175,6 @@
       "MaxValue": "65535",
       "Type": "Number"
     },
-    "GitRepoShareType": {
-      "AllowedValues": [
-        "glusterfs",
-        "nfs"
-      ],
-      "Default": "nfs",
-      "Description": "Type of network share hosting persisted git repository content.",
-      "Type": "String"
-    },
     "GitlabBucket": {
       "AllowedPattern": "^[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]*$|^$",
       "Description": "S3 Bucket to host GitLab files",
@@ -316,7 +293,7 @@
           }
         },
         "TemplateURL": { "Ref": "GitlabEfsTemplate" },
-        "TimeoutInMinutes": "15"
+        "TimeoutInMinutes": 15
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -344,7 +321,7 @@
           }
         },
         "TemplateURL": { "Ref": "GitlabElbTemplate" },
-        "TimeoutInMinutes": "15"
+        "TimeoutInMinutes": 15
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -358,7 +335,7 @@
           "RolePrefix": { "Ref": "RolePrefix" }
         },
         "TemplateURL": { "Ref": "GitlabIamTemplate" },
-        "TimeoutInMinutes": "15"
+        "TimeoutInMinutes": 15
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -383,7 +360,7 @@
           "TargetVPC": { "Ref": "TargetVPC" }
         },
         "TemplateURL": { "Ref": "GitlabRdsTemplate" },
-        "TimeoutInMinutes": "120"
+        "TimeoutInMinutes": 120
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -399,7 +376,7 @@
           "TierToGlacierDays": { "Ref": "TierToGlacierDays" }
         },
         "TemplateURL": { "Ref": "GitlabBucketTemplate" },
-        "TimeoutInMinutes": "15"
+        "TimeoutInMinutes": 15
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -409,7 +386,7 @@
           "TargetVPC": { "Ref": "TargetVPC" }
         },
         "TemplateURL": { "Ref": "SecurityGroupTemplate" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     }

--- a/Templates/make_gitlab_parent-instance-EFS.tmplt.json
+++ b/Templates/make_gitlab_parent-instance-EFS.tmplt.json
@@ -499,7 +499,7 @@
           "SubnetId": { "Ref": "SubNetId" }
         },
         "TemplateURL": { "Ref": "GitlabEc2Template" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -530,7 +530,7 @@
           }
         },
         "TemplateURL": { "Ref": "GitlabElbTemplate" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -547,7 +547,7 @@
           "ServiceTld": { "Ref": "ServiceTld" }
         },
         "TemplateURL": { "Ref": "GitlabEfsTemplate" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -563,7 +563,7 @@
           "ServiceTld": { "Ref": "ServiceTld" }
         },
         "TemplateURL": { "Ref": "GitlabIamTemplate" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -597,7 +597,7 @@
           "GitlabBucket": { "Ref": "GitlabBucket" }
         },
         "TemplateURL": { "Ref": "GitlabBucketTemplate" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -607,7 +607,7 @@
           "TargetVPC": { "Ref": "TargetVPC" }
         },
         "TemplateURL": { "Ref": "SecurityGroupTemplate" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     }


### PR DESCRIPTION
#### Description:

Adds [cfn-python-lint](https://github.com/awslabs/cfn-python-lint) to validation test-set

#### Rationale:

Adding cfn-python-lint to test-set better ensure thats CFn templates are _fucntional_ &mdash; in addition to simply being valid JSON (as performed by previously-existing `jq`-based test)

#### Additional

- Lint the templates already in project so that new test will pass.
- Reorganize `.travis.yml` content