### PR TITLE
Re-architect to run configure as later-running systemd service

### DIFF
--- a/SupportFiles/gitlab_config.sh
+++ b/SupportFiles/gitlab_config.sh
@@ -4,6 +4,7 @@
 #
 #################################################################
 PROGNAME=$(basename "${0}")
+export PATH=${PATH}:/opt/aws/bin
 # Read in template envs we might want to use
 while read -r GLENV
 do
@@ -34,8 +35,8 @@ UPLOADLNK="/var/opt/gitlab/gitlab-rails/uploads"
 # Log errors and exit
 #####
 function err_exit {
-   echo "${1}" > /dev/stderr
-   logger -t "${PROGNAME}" -p kern.crit "${1}"
+   logger -s -t "${PROGNAME}" -p kern.crit "${1}"
+   /etc/cfn/scripts/glprep-signal.sh 1
    exit 1
 }
 
@@ -229,3 +230,8 @@ setenforce 1 || \
    err_exit "Failed to reactivate SELinux"
 echo "Re-enabled SELinux"
 
+# Really only need this to run once...
+systemctl disable gitlab-config.service
+
+# Send success to CFn
+/etc/cfn/scripts/glprep-signal.sh 0

--- a/Templates/make_gitlab_EC2-instance.tmplt.json
+++ b/Templates/make_gitlab_EC2-instance.tmplt.json
@@ -582,12 +582,99 @@
               }
             }
           },
-          "app-install": {
+          "app-prep": {
+            "commands": {
+              "10-config_svc-reload": {
+                "command": "systemctl daemon-reload"
+              },
+              "20-config_svc-reload": {
+                "command": "systemctl enable gitlab-config.service"
+              }
+            },
             "files": {
               "/etc/cfn/scripts/glprep.sh": {
                 "source": { "Ref": "GitLabConfScript" },
                 "group": "root",
                 "mode": "000700",
+                "owner": "root"
+              },
+              "/etc/systemd/system/gitlab-config.service": {
+                "content": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "[Unit]\n",
+                      "Description=Reconfigure GitLab to work on this host\n",
+                      "After=multi-user.target\n",
+                      "\n",
+                      "[Service]\n",
+                      "Type=oneshot\n",
+                      "ExecStart=/etc/cfn/scripts/glprep.sh\n",
+                      "\n",
+                      "[Install]\n",
+                      "WantedBy=multi-user.target\n"
+                    ]
+                  ]
+                },
+                "group": "root",
+                "mode": "000644",
+                "owner": "root"
+              },
+              "/etc/cfn/scripts/glprep-signal.sh": {
+                "content": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "#!/bin/bash\n",
+                      "#\n",
+                      "# Small script to send a post-reboot CFn signal\n",
+                      "#\n",
+                      "###################################################\n",
+                      "PATH=${PATH}:/opt/aws/bin\n",
+                      "\n",
+                      "logger -p kern.info -t ${0} -s \"Sending signal '${1}' to CFn...\"\n",
+                      "\n",
+                      "cfn-signal -e ${1} --stack ",
+                      { "Ref": "AWS::StackName" },
+                      " --resource GitLabMaster",
+                      {
+                        "Fn::If": [
+                          "AssignInstanceRole",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --role ",
+                                { "Ref": "InstanceRoleName" }
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseCfnUrl",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --url ",
+                                { "Ref": "CfnEndpointUrl" }
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      " --region ",
+                      { "Ref": "AWS::Region" },
+                      "\n"
+                    ]
+                  ]
+                },
+                "group": "root",
+                "mode": "000755",
                 "owner": "root"
               },
               "/etc/cron.d/GitLabBackup": {
@@ -647,11 +734,6 @@
                 "mode": "000700",
                 "owner": "root"
               }
-            },
-            "commands": {
-              "10-app-install": {
-                "command": "bash -xe /etc/cfn/scripts/glprep.sh"
-              }
             }
           },
           "configSets": {
@@ -686,12 +768,11 @@
                   "UseCfnAppInstaller",
                   [
                     "gitlab-tmplt-fetch",
-                    "app-install"
+                    "app-prep"
                   ],
                   { "Ref" : "AWS::NoValue" }
                 ]
               },
-              "finalize",
               {
                 "Fn::If": [
                   "Reboot",
@@ -731,12 +812,11 @@
                   "UseCfnAppInstaller",
                   [
                     "gitlab-tmplt-fetch",
-                    "app-install"
+                    "app-prep"
                   ],
                   { "Ref" : "AWS::NoValue" }
                 ]
               },
-              "finalize",
               {
                 "Fn::If": [
                   "Reboot",

--- a/Templates/make_gitlab_ELBv1.tmplt.json
+++ b/Templates/make_gitlab_ELBv1.tmplt.json
@@ -95,7 +95,7 @@
       ],
       "Default": true,
       "Description": "Whether to allow SSH passthrough to GitLab master.",
-      "Type": "Number"
+      "Type": "String"
     },
     "GitLabServicePort": {
       "Default": 80,

--- a/Templates/make_gitlab_parent-infra-EFS.tmplt.json
+++ b/Templates/make_gitlab_parent-infra-EFS.tmplt.json
@@ -150,11 +150,6 @@
       "Description": "Number of days to retain objects before aging them out of the bucket",
       "Type": "Number"
     },
-    "Folder": {
-      "AllowedPattern": "^[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]*$|^$",
-      "Description": "S3 bucket-folder to host backups of GitLab config- and app-data",
-      "Type": "String"
-    },
     "GitLabListenerCert": {
       "Default": "",
       "Description": "Name/ID of the ACM-managed SSL Certificate to protect public listener.",
@@ -356,8 +351,7 @@
               { "Ref": "HaSvcSubnets" }
             ]
           },
-          "PgsqlVersion": { "Ref": "PgsqlVersion" },
-          "TargetVPC": { "Ref": "TargetVPC" }
+          "PgsqlVersion": { "Ref": "PgsqlVersion" }
         },
         "TemplateURL": { "Ref": "GitlabRdsTemplate" },
         "TimeoutInMinutes": 120
@@ -370,7 +364,6 @@
           "BucketInventoryTracking": { "Ref": "BucketInventoryTracking" },
           "BucketName": { "Ref": "GitlabBucket" },
           "FinalExpirationDays": { "Ref": "FinalExpirationDays" },
-          "Folder": { "Ref": "Folder" },
           "ReportingBucket": { "Ref": "ReportingBucket" },
           "RetainIncompleteDays": { "Ref": "RetainIncompleteDays" },
           "TierToGlacierDays": { "Ref": "TierToGlacierDays" }


### PR DESCRIPTION
#### Description:

Update to make compatible with 11.2.x+'s new systemd dependency-order

#### Rationale:

Whith 11.2.x and newer GitLab versions, the gitlab-runsvc service won't start until `multi-user.target`. The `cloud-init` and `cfn-init` elements run _before_ `multi-user.target`. This creates an unresolveable dependency that this PR resolves.